### PR TITLE
Fix bug where you cannot download maps spanning tilesets across powers of 10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# maptiles 0.3.1
+
+## Bug fixes
+* Fix issue that stopped downloading tile sets that span different orders of magnitude
+
 # maptiles 0.3.0
 
 ## Minor changes

--- a/R/get_tiles.R
+++ b/R/get_tiles.R
@@ -229,6 +229,9 @@ dl_t <- function(x, z, ext, src, q, verbose, cachedir, forceDownload) {
     cachedir <- subdir
   }
 
+  # apply coerces to the same length character, need to ensure no whitespace in numbers
+  x <- trimws(x)
+
   outfile <- paste0(cachedir, "/", src, "_", z, "_", x[1], "_", x[2], ".", ext)
   if (!file.exists(outfile) | isTRUE(forceDownload)) {
     q <- gsub(pattern = "{s}", replacement = x[3], x = q, fixed = TRUE)


### PR DESCRIPTION
Small issue I found but was easy enough to fix on a local clone so wanted to just contribute it - it might not be the most elegant way but it solves the issue using a base function.

The issue is that `apply` coerces everything to a character for the OSM maps when the `x` value is passed into the `dl_t` function which causes a failure when you are downloading a tileset that spans (on the x or y columns) values with a different number of units such as in the below example.

``` r
library(maptiles)
#> Warning: package 'maptiles' was built under R version 4.1.3
library(sf)
#> Warning: package 'sf' was built under R version 4.1.3
#> Linking to GEOS 3.10.2, GDAL 3.4.1, PROJ 7.2.1; sf_use_s2() is TRUE

a = st_sf(a = 1:2, geom = st_sfc(st_point(c(-8.177926, 49.8847)), st_point(c(1.763016, 60.84555))), crs = 4326)
get_tiles(x = a, crop = TRUE, cachedir = 'Tiles', zoom = 5, verbose = TRUE)
#> http://b.tile.openstreetmap.org/5/15/ 9.png => Tiles/OpenStreetMap/OpenStreetMap_5_15_ 9.png
#> Error in curl::curl_download(url = q, destfile = outfile): HTTP error 400.
```

<sup>Created on 2022-08-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


This change fixes this issue and correctly completes the filename

``` r
library(maptiles) # locally built version with change.
library(sf)
#> Warning: package 'sf' was built under R version 4.1.3
#> Linking to GEOS 3.10.2, GDAL 3.4.1, PROJ 7.2.1; sf_use_s2() is TRUE

a = st_sf(a = 1:2, geom = st_sfc(st_point(c(-8.177926, 49.8847)), st_point(c(1.763016, 60.84555))), crs = 4326)
get_tiles(x = a, crop = TRUE, cachedir = 'Tiles', zoom = 5, verbose = TRUE)
#> http://a.tile.openstreetmap.org/5/15/9.png => Tiles/OpenStreetMap/OpenStreetMap_5_15_9.png
#> http://c.tile.openstreetmap.org/5/16/9.png => Tiles/OpenStreetMap/OpenStreetMap_5_16_9.png
#> http://c.tile.openstreetmap.org/5/15/10.png => Tiles/OpenStreetMap/OpenStreetMap_5_15_10.png
#> http://b.tile.openstreetmap.org/5/16/10.png => Tiles/OpenStreetMap/OpenStreetMap_5_16_10.png
#> Zoom:5
#> Data and map tiles sources:
#> © OpenStreetMap contributors
#> class       : SpatRaster 
#> dimensions  : 336, 307, 3  (nrow, ncol, nlyr)
#> resolution  : 0.0357, 0.0357  (x, y)
#> extent      : -8.6796, 2.2803, 49.37146, 61.36666  (xmin, xmax, ymin, ymax)
#> coord. ref. : lon/lat WGS 84 (EPSG:4326) 
#> source      : memory 
#> colors RGB  : 1, 2, 3 
#> names       : red, green, blue 
#> min values  :   4,     4,    4 
#> max values  : 252,   252,  250
```

<sup>Created on 2022-08-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I updated the news but left the version number increased on the DESCRIPTION as this already didn't match so was unsure if that needed changing.

Hopefully this helps!