### PR TITLE
for #16

### DIFF
--- a/man/get_tiles.Rd
+++ b/man/get_tiles.Rd
@@ -9,6 +9,8 @@ get_tiles(
   provider = "OpenStreetMap",
   zoom,
   crop = FALSE,
+  project = TRUE,
+  prvcrs = "epsg:3857",
   verbose = FALSE,
   apikey,
   cachedir,
@@ -30,6 +32,10 @@ q = "server address", sub = "subdomains", cit = "how to cite the tiles")}
 
 \item{crop}{TRUE if results should be cropped to the specified x extent,
 FALSE otherwise. If x is an sf object with one POINT, crop is set to FALSE.}
+
+\item{project}{if TRUE, the output is projected to the crs of x.}
+
+\item{prvcrs}{the crs used by the provider}
 
 \item{verbose}{if TRUE, tiles filepaths, zoom level and citation are displayed.}
 


### PR DESCRIPTION
This PR introduces two new arguments `project=TRUE` and `prvcrs = "epsg:3857"` to allow using a provider that serves tiles with a crs that is *not* `epsg:3857`.

prvcrs allows for setting the crs that comes with the provider tiles. Perhaps that can be obtained in other ways in some cases, but this is an easy way that allows to make things work. 

Setting `project=FALSE` is useful when one is not sure about the provider crs, so you can look at the original data. But it is also useful in general. And given the quality degradation from projection, perhaps it should have been the default. Another reason for having itis that the projection method used is "bilinear", whereas for many of the data sources one may prefer "nearest" instead. 

I did not have an example of a working provider with a crs that is not the default (the examples in the issues currently do not work). It would be useful to have one for more testing.
