### PR TITLE
Add wmts doc to create_provider

### DIFF
--- a/R/create_provider.R
+++ b/R/create_provider.R
@@ -42,7 +42,7 @@
 #'   citation = "IGN, BD ORTHO®"
 #' )
 #'
-#' # Find tilematrixset and style values
+#' # Find TileMatrixSet and Style values
 #'
 #' layer <- "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO"
 #' path <- "https://wxs.ign.fr/ortho/geoportail/wmts?"

--- a/R/create_provider.R
+++ b/R/create_provider.R
@@ -12,6 +12,7 @@
 #' @return a list is returned. This list can be used by \link{get_tiles}.
 #' @export
 #' @examples
+#' \dontrun{
 #' statdia_toner <- create_provider(
 #'   name = "stadia_stamen_toner",
 #'   url = "https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}.png?api_key={apikey}",
@@ -27,19 +28,33 @@
 #'   name = "orthophoto_IGN",
 #'   url = paste0(
 #'     "https://wxs.ign.fr/ortho/geoportail/wmts?",
-#'     "&REQUEST=GetTile",
-#'     "&SERVICE=WMTS",
-#'     "&VERSION=1.0.0",
-#'     "&STYLE=normal",
-#'     "&TILEMATRIXSET=PM",
-#'     "&FORMAT=image/jpeg",
-#'     "&LAYER=ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
-#'     "&TILEMATRIX={z}",
-#'     "&TILEROW={y}",
-#'     "&TILECOL={x}"
+#'     "request=GetTile",
+#'     "&service=WMTS",
+#'     "&version=1.0.0",
+#'     "&style=normal",
+#'     "&tilematrixset=PM",
+#'     "&format=image/jpeg",
+#'     "&layer=ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
+#'     "&tilematrix={z}",
+#'     "&tilerow={y}",
+#'     "&tilecol={x}"
 #'   ),
 #'   citation = "IGN, BD ORTHO®"
 #' )
+#'
+#' # Find tilematrixset and style values
+#'
+#' layer <- "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO"
+#' path <- "https://wxs.ign.fr/ortho/geoportail/wmts?"
+#' param_info <- "service=wmts&request=GetCapabilities&version=1.0.0"
+#' url <- paste0("WMTS:", path, param_info, ",layer=", layer)
+#'
+#' tmp <- tempfile(fileext = ".xml")
+#' sf::gdal_utils("translate",
+#'                url, tmp,
+#'                options = c("-of", "WMTS"))
+#' readLines(tmp)
+#' }
 create_provider <- function(name, url, sub = NA, citation) {
   return(list(src = name, q = url, sub = sub, cit = citation))
 }

--- a/man/create_provider.Rd
+++ b/man/create_provider.Rd
@@ -24,6 +24,7 @@ a list is returned. This list can be used by \link{get_tiles}.
 Use this function to create new tiles provider.
 }
 \examples{
+\dontrun{
 statdia_toner <- create_provider(
   name = "stadia_stamen_toner",
   url = "https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}.png?api_key={apikey}",
@@ -39,17 +40,31 @@ IGN <- create_provider(
   name = "orthophoto_IGN",
   url = paste0(
     "https://wxs.ign.fr/ortho/geoportail/wmts?",
-    "&REQUEST=GetTile",
-    "&SERVICE=WMTS",
-    "&VERSION=1.0.0",
-    "&STYLE=normal",
-    "&TILEMATRIXSET=PM",
-    "&FORMAT=image/jpeg",
-    "&LAYER=ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
-    "&TILEMATRIX={z}",
-    "&TILEROW={y}",
-    "&TILECOL={x}"
+    "request=GetTile",
+    "&service=WMTS",
+    "&version=1.0.0",
+    "&style=normal",
+    "&tilematrixset=PM",
+    "&format=image/jpeg",
+    "&layer=ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO",
+    "&tilematrix={z}",
+    "&tilerow={y}",
+    "&tilecol={x}"
   ),
   citation = "IGN, BD ORTHO®"
 )
+
+# Find tilematrixset and style values
+
+layer <- "ORTHOIMAGERY.ORTHOPHOTOS.BDORTHO"
+path <- "https://wxs.ign.fr/ortho/geoportail/wmts?"
+param_info <- "service=wmts&request=GetCapabilities&version=1.0.0"
+url <- paste0("WMTS:", path, param_info, ",layer=", layer)
+
+tmp <- tempfile(fileext = ".xml")
+sf::gdal_utils("translate",
+               url, tmp,
+               options = c("-of", "WMTS"))
+readLines(tmp)
+}
 }


### PR DESCRIPTION
Reference from #22 

I add some lines to explain how to get TileMatrixSet and Style values from WMTS in create_provider documentation.

To avoid tests failing because there is no internet connection, I add `\dontrun{}` inside documentation.